### PR TITLE
fix legacy open throwing abortError

### DIFF
--- a/src/legacy/directory-open.mjs
+++ b/src/legacy/directory-open.mjs
@@ -28,9 +28,15 @@ export default async (options = {}) => {
 
     const cancelDetector = () => {
       window.removeEventListener('focus', cancelDetector);
-      if (input.files.length === 0) {
-        reject(new DOMException('The user aborted a request.', 'AbortError'));
-      }
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          if (input.files.length === 0) {
+            reject(
+              new DOMException('The user aborted a request.', 'AbortError')
+            );
+          }
+        });
+      });
     };
 
     input.addEventListener('click', () => {

--- a/src/legacy/file-open.mjs
+++ b/src/legacy/file-open.mjs
@@ -31,9 +31,15 @@ export default async (options = {}) => {
 
     const cancelDetector = () => {
       window.removeEventListener('focus', cancelDetector);
-      if (input.files.length === 0) {
-        reject(new DOMException('The user aborted a request.', 'AbortError'));
-      }
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          if (input.files.length === 0) {
+            reject(
+              new DOMException('The user aborted a request.', 'AbortError')
+            );
+          }
+        });
+      });
     };
 
     input.addEventListener('click', () => {


### PR DESCRIPTION
fix https://github.com/GoogleChromeLabs/browser-fs-access/issues/36

This breaks opening any files in Excalidraw. The solution isn't 100% safe though. Personally, I'd drop the `AbortError` hack altogether.