### PR TITLE
checking if app is running in third- or first-party environment

### DIFF
--- a/src/supported.mjs
+++ b/src/supported.mjs
@@ -16,7 +16,8 @@
 // @license © 2020 Google LLC. Licensed under the Apache License, Version 2.0.
 
 const supported = (() => {
-  if ('chooseFileSystemEntries' in self) {
+  if (window.self !== window.top) return false;
+  else if ('chooseFileSystemEntries' in self) {
     return 'chooseFileSystemEntries';
   } else if ('showOpenFilePicker' in self) {
     return 'showOpenFilePicker';

--- a/src/supported.mjs
+++ b/src/supported.mjs
@@ -16,8 +16,18 @@
 // @license © 2020 Google LLC. Licensed under the Apache License, Version 2.0.
 
 const supported = (() => {
-  if (window.self !== window.top) return false;
-  else if ('chooseFileSystemEntries' in self) {
+  // ToDo: Remove this check once Permissions Policy integration
+  // has happened, tracked in
+  // https://github.com/WICG/file-system-access/issues/245.
+  if (self !== top) {
+    try {      
+      // This will succeed on same-origin iframes,
+      // but fail on cross-origin iframes.
+      top.location + '';
+    } catch {      
+      return false;
+    }
+  } else if ('chooseFileSystemEntries' in self) {
     return 'chooseFileSystemEntries';
   } else if ('showOpenFilePicker' in self) {
     return 'showOpenFilePicker';


### PR DESCRIPTION
hey @tomayac ,
i saw issue filled on the repo, https://github.com/GoogleChromeLabs/browser-fs-access/issues/38,
i tired to fix this my adding a small check in supported function.
i even tested the solution by embedding the demo project in the repo inside an iframe, it works well.
i have a dependency of this fix , as `browser-fs-access` is been used by `excalidraw` board, which we want to use inside iframe in our application, so if you could review and publish module to npm, i would be really helpful of you !

Thanking in anticipation