### PR TITLE
[fix][NPM] Add package.json to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "File System Access API with legacy fallback in the browser.",
   "browser": "./dist/index.js",
   "main": "./dist/index.js",
-  "exports": "./dist/index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./package.json": "./package.json"
+  },
   "module": "./dist/index.js",
   "types": "./index.d.ts",
   "scripts": {


### PR DESCRIPTION
Update package.json exports to include package.json. Why package.json
needs to export itself, I cannot say but it fixes the following Svelte
rollup.js plugin warning:

  [rollup-plugin-svelte] The following packages did not export their `package.json` file so we could not check the "svelte" field. If you had difficulties importing svelte components from a package, then please contact the author and ask them to export the package.json file.

  - browser-fs-access

I've verified locally using `npm link` that the warning no longer occurs
with this change in my Svelte project. I _believe_ the otherwise
preexisting exports behavior is preserved.

References:
- [Official documentation](https://nodejs.org/api/packages.html#packages_exports) and [much more useful documentation with examples from the proposal](https://github.com/jkrems/proposal-pkg-exports)
- [Similar issue for a different package](https://github.com/sveltejs/svelte/issues/5659) and [its resolution](https://unpkg.com/svelte@3.29.6/package.json)