### PR TITLE
fix: TypeScript declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -77,9 +77,7 @@ export interface FirstFileOpenOptions<M extends boolean | undefined>
  * Opens file(s) from disk.
  */
 export function fileOpen<M extends boolean | undefined = false>(
-  options?: O extends any[]
-    ? [FirstFileOpenOptions<M>, ...CoreFileOptions[]]
-    : FirstFileOpenOptions<M>
+  options?: [FirstFileOpenOptions<M>, ...CoreFileOptions[]] | FirstFileOpenOptions<M>
 ): M extends false | undefined
   ? Promise<FileWithHandle>
   : Promise<FileWithHandle[]>;
@@ -99,9 +97,7 @@ export type WellKnownDirectory =
 export function fileSave(
   /** To-be-saved blob */
   blob: Blob,
-  options?: O extends any[]
-    ? [FirstFileSaveOptions, ...CoreFileOptions[]]
-    : FirstFileSaveOptions,
+  options?: [FirstFileSaveOptions, ...CoreFileOptions[]] | FirstFileSaveOptions,
   /**
    * A potentially existing file handle for a file to save to. Defaults to
    * null.


### PR DESCRIPTION
Previously, the functions `fileOpen` and  `fileSave` used an **_undefined_** generic type of `O`. This caused TypeScript compiler issues in some environments. ([details in commit discussion](https://github.com/GoogleChromeLabs/browser-fs-access/commit/e1da0828b2c9843b18cb4047e08f9e49599a97bd#r54845530))

If I understand the types correctly, the generic type O is not needed. We just want TypeScript to know that options is either of the array type `[FirstFileSaveOptions, ...CoreFileOptions[]]` or of the object type `FirstFileSaveOptions`.