### PR TITLE
Fix fileSave return type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -111,7 +111,7 @@ export function fileSave(
    * when existingHandle is no longer good. Defaults to false.
    */
   throwIfExistingHandleNotGood?: boolean | false
-): Promise<FileSystemHandle>;
+): Promise<FileSystemHandle | null>;
 
 /**
  * Opens a directory from disk using the File System Access API.

--- a/src/legacy/file-save.mjs
+++ b/src/legacy/file-save.mjs
@@ -43,4 +43,5 @@ export default async (blob, options = {}) => {
     setTimeout(() => URL.revokeObjectURL(a.href), 30 * 1000);
   });
   a.click();
+  return null;
 };


### PR DESCRIPTION
The docs for fileSave() are correct, the return type is optional.
However, the typing promised to always return a defined
FileSystemHandle. This patch makes the return type optional to forgive
the legacy behavior.

`null` is used over `undefined` to match project typing conventions. As
such, a functional change to unconditionally `return null` was necessary
in the legacy implementation.