### PR TITLE
Add a callback to skip the opening of a recursive directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ const options = {
   startIn: 'downloads',
   // By specifying an ID, the user agent can remember different directories for different IDs.
   id: 'projects',
+  // Callback whether a directory needs to be opened, return true to skip
+  skipDirectory: (entry) => entry.name[0] === '.',
 };
 
 const blobs = await directoryOpen(options);

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ const options = {
   startIn: 'downloads',
   // By specifying an ID, the user agent can remember different directories for different IDs.
   id: 'projects',
-  // Callback whether a directory needs to be opened, return true to skip
+  // Callback to determine whether a directory should be entered, return `true` to skip.
   skipDirectory: (entry) => entry.name[0] === '.',
 };
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -161,8 +161,10 @@ export function directoryOpen(options?: {
   startIn?: WellKnownDirectory | FileSystemHandle;
   /** By specifying an ID, the user agent can remember different directories for different IDs. */
   id?: string;
-  /** Callback whether a directory needs to be opened, return false to skip */
-  skipDirectory?: (fileSystemDirectoryEntry: FileSystemDirectoryEntry) => boolean;
+  /** Callback to determine whether a directory should be entered, return `true` to skip. */
+  skipDirectory?: (
+    fileSystemDirectoryEntry: FileSystemDirectoryEntry
+  ) => boolean;
   /**
    * Configurable setup, cleanup and `Promise` rejector usable with legacy API
    * for determining when (and reacting if) a user cancels the operation. The

--- a/index.d.ts
+++ b/index.d.ts
@@ -162,7 +162,7 @@ export function directoryOpen(options?: {
   /** By specifying an ID, the user agent can remember different directories for different IDs. */
   id?: string;
   /** Callback whether a directory needs to be opened, return false to skip */
-  skipDirectory?: (FileSystemDirectoryHandle) => boolean;
+  skipDirectory?: (fileSystemDirectoryEntry: FileSystemDirectoryEntry) => boolean;
   /**
    * Configurable setup, cleanup and `Promise` rejector usable with legacy API
    * for determining when (and reacting if) a user cancels the operation. The

--- a/index.d.ts
+++ b/index.d.ts
@@ -161,6 +161,8 @@ export function directoryOpen(options?: {
   startIn?: WellKnownDirectory | FileSystemHandle;
   /** By specifying an ID, the user agent can remember different directories for different IDs. */
   id?: string;
+  /** Callback whether a directory needs to be opened, return false to skip */
+  skipDirectory?: (FileSystemDirectoryHandle) => boolean;
   /**
    * Configurable setup, cleanup and `Promise` rejector usable with legacy API
    * for determining when (and reacting if) a user cancels the operation. The

--- a/src/fs-access/directory-open.mjs
+++ b/src/fs-access/directory-open.mjs
@@ -15,7 +15,7 @@
  */
 // @license © 2020 Google LLC. Licensed under the Apache License, Version 2.0.
 
-const getFiles = async (dirHandle, recursive, path = dirHandle.name) => {
+const getFiles = async (dirHandle, recursive, path = dirHandle.name, skipDirectory) => {
   const dirs = [];
   const files = [];
   for await (const entry of dirHandle.values()) {
@@ -31,8 +31,8 @@ const getFiles = async (dirHandle, recursive, path = dirHandle.name) => {
           });
         })
       );
-    } else if (entry.kind === 'directory' && recursive) {
-      dirs.push(getFiles(entry, recursive, nestedPath));
+    } else if (entry.kind === 'directory' && recursive && (!skipDirectory || !skipDirectory(entry))) {
+      dirs.push(getFiles(entry, recursive, nestedPath, skipDirectory));
     }
   }
   return [...(await Promise.all(dirs)).flat(), ...(await Promise.all(files))];
@@ -48,5 +48,5 @@ export default async (options = {}) => {
     id: options.id,
     startIn: options.startIn,
   });
-  return getFiles(handle, options.recursive);
+  return getFiles(handle, options.recursive, undefined, options.skipDirectory);
 };

--- a/src/fs-access/directory-open.mjs
+++ b/src/fs-access/directory-open.mjs
@@ -15,7 +15,12 @@
  */
 // @license © 2020 Google LLC. Licensed under the Apache License, Version 2.0.
 
-const getFiles = async (dirHandle, recursive, path = dirHandle.name, skipDirectory) => {
+const getFiles = async (
+  dirHandle,
+  recursive,
+  path = dirHandle.name,
+  skipDirectory
+) => {
   const dirs = [];
   const files = [];
   for await (const entry of dirHandle.values()) {
@@ -31,7 +36,11 @@ const getFiles = async (dirHandle, recursive, path = dirHandle.name, skipDirecto
           });
         })
       );
-    } else if (entry.kind === 'directory' && recursive && (!skipDirectory || !skipDirectory(entry))) {
+    } else if (
+      entry.kind === 'directory' &&
+      recursive &&
+      (!skipDirectory || !skipDirectory(entry))
+    ) {
       dirs.push(getFiles(entry, recursive, nestedPath, skipDirectory));
     }
   }

--- a/src/legacy/directory-open.mjs
+++ b/src/legacy/directory-open.mjs
@@ -49,7 +49,14 @@ export default async (options = [{}]) => {
         files = files.filter((file) => {
           return file.webkitRelativePath.split('/').length === 2;
         });
+      } else if (options[0].recursive && options[0].skipDirectory) {
+        files = files.filter((file) => {
+          const directoriesName = file.webkitRelativePath.split('/');
+
+          return directoriesName.every((directoryName) => !options[0].skipDirectory({ name: directoryName, kind: 'directory' }));
+        });
       }
+
       _resolve(files);
     });
 

--- a/src/legacy/directory-open.mjs
+++ b/src/legacy/directory-open.mjs
@@ -52,8 +52,13 @@ export default async (options = [{}]) => {
       } else if (options[0].recursive && options[0].skipDirectory) {
         files = files.filter((file) => {
           const directoriesName = file.webkitRelativePath.split('/');
-
-          return directoriesName.every((directoryName) => !options[0].skipDirectory({ name: directoryName, kind: 'directory' }));
+          return directoriesName.every(
+            (directoryName) =>
+              !options[0].skipDirectory({
+                name: directoryName,
+                kind: 'directory',
+              })
+          );
         });
       }
 


### PR DESCRIPTION
This PR allows passing a callback to say whether we want to open this directory based on the developer criteria (such as the name for example). For example, you can skip the directory with a name beginning with a point ('.git', '.backup', etc.).