### PR TITLE
fix accept string when using mimeTypes

### DIFF
--- a/src/legacy/file-open.mjs
+++ b/src/legacy/file-open.mjs
@@ -27,8 +27,8 @@ export default async (options = [{}]) => {
     const input = document.createElement('input');
     input.type = 'file';
     const accept = [
-      ...options.map((option) => option.mimeTypes || []).join(),
-      options.map((option) => option.extensions || []).join(),
+      ...options.map((option) => option.mimeTypes || []),
+      ...options.map((option) => option.extensions || []),
     ].join();
     input.multiple = options[0].multiple || false;
     // Empty string allows everything.


### PR DESCRIPTION
I am trying to start using this library in one of my projects.

When I converted my existing app (which was using an `<input type="file" />`) to using the following code:

```
fileOpen({ mimeTypes: ['audio/*'] })
```

I noticed that my `audio/*` filter was no longer being applied.

I added some debugging code to dump the `<input type="file" />` that is being generated by this library, and I noticed `<input accept="a,u,d,i,o,/,*," />` is being generated:

<img width="310" alt="image" src="https://user-images.githubusercontent.com/434470/154859018-e727ee37-b533-444b-87dc-090ffab02032.png">

To understand the effect of this code change, please see the following 2 examples:

## case 1 (both mimeTypes and extensions):
before pr:
```
console.log(
  [
    ...['one','two'].join(),
    ['three','four'].join()
  ].join()
);
// o,n,e,,,t,w,o,three,four
```

after pr:
```
console.log(
  [
    ...['one','two'],
    ...['three','four']
  ].join()
);
// one,two,three,four
```

## case 2 (only extensions):
before pr:
```
console.log(
  [
    ...[].join(),
    ['one','two'].join()
  ].join()
);
// one,two
```

after pr:
```
console.log(
  [
    ...[],
    ...['one','two']
  ].join()
);
// one,two
```
