### PR TITLE
removed usage of Response.type

### DIFF
--- a/src/fs-access/file-save.mjs
+++ b/src/fs-access/file-save.mjs
@@ -37,9 +37,7 @@ export default async (
     };
     if (option.mimeTypes) {
       if (i === 0) {
-        if (blobOrResponse.type) {
-          option.mimeTypes.push(blobOrResponse.type);
-        } else if (
+        if (
           blobOrResponse.headers &&
           blobOrResponse.headers.get('content-type')
         ) {
@@ -49,8 +47,6 @@ export default async (
       option.mimeTypes.map((mimeType) => {
         types[i].accept[mimeType] = option.extensions || [];
       });
-    } else if (blobOrResponse.type) {
-      types[i].accept[blobOrResponse.type] = option.extensions || [];
     }
   });
   if (existingHandle) {


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/API/Response/type the Response.type has nothing to do with mimeTypes, and using it in showSaveFilePicker() produces an error (at least in chrome), so I removed the usages.