### PR TITLE
add callback informing about handle creation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -139,11 +139,6 @@ export function fileSave(
   blobOrResponse: Blob | Response,
   options?: [FirstFileSaveOptions, ...CoreFileOptions[]] | FirstFileSaveOptions,
   /**
-   * A callback to be called when the file picker was shown (which only happens
-   * when no existingHandle is provided). Defaults to null.
-   */
-  filePickerShownCb?: () => void | null,
-  /**
    * A potentially existing file handle for a file to save to. Defaults to
    * null.
    */
@@ -152,7 +147,12 @@ export function fileSave(
    * Determines whether to throw (rather than open a new file save dialog)
    * when existingHandle is no longer good. Defaults to false.
    */
-  throwIfExistingHandleNotGood?: boolean | false
+  throwIfExistingHandleNotGood?: boolean | false,
+  /**
+   * A callback to be called when the file picker was shown (which only happens
+   * when no existingHandle is provided). Defaults to null.
+   */
+  filePickerShownCb?: () => void | null   
 ): Promise<FileSystemHandle | null>;
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,11 +2,11 @@
  * Properties shared by all `options` provided to file save and open operations
  */
 export interface CoreFileOptions {
-  /** Acceptable file extensions. Defaults to [""]. */
+  /** Acceptable file extensions. Defaults to `[""]`. */
   extensions?: string[];
-  /** Suggested file description. Defaults to "". */
+  /** Suggested file description. Defaults to `""`. */
   description?: string;
-  /** Acceptable MIME types. [] */
+  /** Acceptable MIME types. Defaults to `[]`. */
   mimeTypes?: string[];
 }
 
@@ -27,7 +27,7 @@ export interface FirstCoreFileOptions extends CoreFileOptions {
  * a filename
  */
 export interface FirstFileSaveOptions extends FirstCoreFileOptions {
-  /** Suggested file name. Defaults to "Untitled". */
+  /** Suggested file name. Defaults to `"Untitled"`. */
   fileName?: string;
   /**
    * Configurable cleanup and `Promise` rejector usable with legacy API for
@@ -72,7 +72,7 @@ export interface FirstFileSaveOptions extends FirstCoreFileOptions {
  */
 export interface FirstFileOpenOptions<M extends boolean | undefined>
   extends FirstCoreFileOptions {
-  /** Allow multiple files to be selected. Defaults to false. */
+  /** Allow multiple files to be selected. Defaults to `false`. */
   multiple?: M;
   /**
    * Configurable cleanup and `Promise` rejector usable with legacy API for
@@ -140,19 +140,19 @@ export function fileSave(
   options?: [FirstFileSaveOptions, ...CoreFileOptions[]] | FirstFileSaveOptions,
   /**
    * A potentially existing file handle for a file to save to. Defaults to
-   * null.
+   * `null`.
    */
   existingHandle?: FileSystemHandle | null,
   /**
    * Determines whether to throw (rather than open a new file save dialog)
-   * when existingHandle is no longer good. Defaults to false.
+   * when `existingHandle` is no longer good. Defaults to `false`.
    */
   throwIfExistingHandleNotGood?: boolean | false,
   /**
    * A callback to be called when the file picker was shown (which only happens
-   * when no existingHandle is provided). Defaults to null.
+   * when no `existingHandle` is provided). Defaults to `null`.
    */
-  filePickerShownCb?: () => void | null   
+  filePickerShown?: () => void | null   
 ): Promise<FileSystemHandle | null>;
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -139,6 +139,11 @@ export function fileSave(
   blobOrResponse: Blob | Response,
   options?: [FirstFileSaveOptions, ...CoreFileOptions[]] | FirstFileSaveOptions,
   /**
+   * A callback to be called when the file picker was shown (which only happens
+   * when no existingHandle is provided). Defaults to null.
+   */
+  filePickerShownCb?: () => void | null,
+  /**
    * A potentially existing file handle for a file to save to. Defaults to
    * null.
    */

--- a/src/fs-access/file-save.mjs
+++ b/src/fs-access/file-save.mjs
@@ -22,6 +22,7 @@
 export default async (
   blobOrResponse,
   options = [{}],
+  filePickerShownCb = null,
   existingHandle = null,
   throwIfExistingHandleNotGood = false
 ) => {
@@ -73,6 +74,9 @@ export default async (
       types,
       excludeAcceptAllOption: options[0].excludeAcceptAllOption || false,
     }));
+  if (!existingHandle && filePickerShownCb) {
+    filePickerShownCb();
+  }
   const writable = await handle.createWritable();
   // Use streaming on the `Blob` if the browser supports it.
   if ('stream' in blobOrResponse) {

--- a/src/fs-access/file-save.mjs
+++ b/src/fs-access/file-save.mjs
@@ -22,9 +22,9 @@
 export default async (
   blobOrResponse,
   options = [{}],
-  filePickerShownCb = null,
   existingHandle = null,
-  throwIfExistingHandleNotGood = false
+  throwIfExistingHandleNotGood = false,
+  filePickerShownCb = null
 ) => {
   if (!Array.isArray(options)) {
     options = [options];

--- a/src/fs-access/file-save.mjs
+++ b/src/fs-access/file-save.mjs
@@ -24,7 +24,7 @@ export default async (
   options = [{}],
   existingHandle = null,
   throwIfExistingHandleNotGood = false,
-  filePickerShownCb = null
+  filePickerShown = null
 ) => {
   if (!Array.isArray(options)) {
     options = [options];
@@ -74,8 +74,8 @@ export default async (
       types,
       excludeAcceptAllOption: options[0].excludeAcceptAllOption || false,
     }));
-  if (!existingHandle && filePickerShownCb) {
-    filePickerShownCb();
+  if (!existingHandle && filePickerShown) {
+    filePickerShown();
   }
   const writable = await handle.createWritable();
   // Use streaming on the `Blob` if the browser supports it.


### PR DESCRIPTION
In my use case I want to save a file which is received in byte chunks from a WebAssembly component.
For this I need the information when the user has selected a destination for the file, so I can trigger the start of the transfer of the file.

Starting the transfer beforehand would be possible as well, but should the user cancel out of the save file dialog, it would result in transferred data for no purpose.