### PR TITLE
Fix reader management

### DIFF
--- a/src/legacy/file-save.mjs
+++ b/src/legacy/file-save.mjs
@@ -85,6 +85,7 @@ async function streamToBlob(stream, type) {
   });
 
   const res = new Response(pumpedStream);
+  const blob = await res.blob();
   reader.releaseLock();
-  return new Blob([await res.blob()], { type });
+  return new Blob([blob], { type });
 }


### PR DESCRIPTION
Discussion in https://github.com/GoogleChromeLabs/browser-fs-access/issues/100#issuecomment-1100121554

I think that this is a bug that breaks file saving for all legacy browsers using streams: the incoming stream is closed _before_ it is fully read into the other ReadableStream instance.