### PR TITLE
Support Promise<Blob> as input

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -33,6 +33,7 @@
     </button>
     <button id="open-directory" disabled type="button">Open Directory</button>
     <button id="save" disabled type="button">Save Image File</button>
+    <button id="save-blob" disabled type="button">Save Promise Blob</button>
     <pre></pre>
   </body>
 </html>

--- a/demo/script.mjs
+++ b/demo/script.mjs
@@ -24,6 +24,7 @@ import { imageToBlob } from './image-to-blob.mjs';
   const openImageOrTextButton = document.querySelector('#open-image-or-text');
   const openDirectoryButton = document.querySelector('#open-directory');
   const saveButton = document.querySelector('#save');
+  const saveBlobButton = document.querySelector('#save-blob');
   const supportedParagraph = document.querySelector('.supported');
   const pre = document.querySelector('pre');
 
@@ -152,9 +153,25 @@ import { imageToBlob } from './image-to-blob.mjs';
     }
   });
 
+  saveBlobButton.addEventListener('click', async () => {
+    const blob = imageToBlob(document.querySelector('img'));
+    try {
+      await fileSave(blob, {
+        fileName: 'floppy.png',
+        extensions: ['.png'],
+      });
+    } catch (err) {
+      if (err.name !== 'AbortError') {
+        return console.error(err);
+      }
+      console.log(ABORT_MESSAGE);
+    }
+  });
+
   openButton.disabled = false;
   openMultipleButton.disabled = false;
   openImageOrTextButton.disabled = false;
   openDirectoryButton.disabled = false;
   saveButton.disabled = false;
+  saveBlobButton.disabled = false;
 })();

--- a/index.d.ts
+++ b/index.d.ts
@@ -136,7 +136,7 @@ export type WellKnownDirectory =
  */
 export function fileSave(
   /** To-be-saved `Blob` or `Response` */
-  blobOrResponse: Blob | Response,
+  blobOrResponse: Blob | Response | Promise<Blob>,
   options?: [FirstFileSaveOptions, ...CoreFileOptions[]] | FirstFileSaveOptions,
   /**
    * A potentially existing file handle for a file to save to. Defaults to

--- a/src/fs-access/file-save.mjs
+++ b/src/fs-access/file-save.mjs
@@ -91,7 +91,7 @@ export default async (
     return handle;
   }
   // Default case of `Blob` passed and `Blob.stream()` not supported.
-  await writable.write(blobOrResponse);
+  await writable.write(await blobOrResponse);
   await writable.close();
   return handle;
 };

--- a/src/legacy/file-save.mjs
+++ b/src/legacy/file-save.mjs
@@ -33,7 +33,7 @@ export default async (blobOrResponse, options = {}) => {
     );
   }
   a.download = options.fileName || 'Untitled';
-  a.href = URL.createObjectURL(data);
+  a.href = URL.createObjectURL(await data);
 
   const _reject = () => cleanupListenersAndMaybeReject(reject);
   const _resolve = () => {


### PR DESCRIPTION
Okay, this is another approach to https://github.com/GoogleChromeLabs/browser-fs-access/pull/104 because it is turning out to be extremely difficult to support Safari and Firefox and implement streams.

Instead of doing a roundtrip from Blob to Response (with a handcrafted ReadableStream), this just lets you pass a `Promise<Blob>` to browser-fs-access. Much simpler, and much harder to mess up. I've tried many variations of creating a ReadableStream object that works across browsers as the data of a Response. There are almost no examples of properly doing so, it's very easy to get it wrong, and it's unnecessary indirection for both browser-fs-access and module consumers if the data is originally in some Blob or string format.