### PR TITLE
fix: stop passing undefined `reject` in legacy file-save setup handler

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -58,10 +58,10 @@ export interface FirstFileSaveOptions extends FirstCoreFileOptions {
    *   https://github.com/whatwg/html/issues/6376 is specified and supported.
    */
   legacySetup?: (
-    resolve: (value: Blob) => void,
+    resolve: () => void,
     rejectionHandler: () => void,
     anchor: HTMLAnchorElement
-  ) => (reject?: (reason?: any) => void) => void;
+  ) => () => void;
 }
 
 /**

--- a/src/legacy/file-save.mjs
+++ b/src/legacy/file-save.mjs
@@ -35,7 +35,7 @@ export default async (blobOrResponse, options = {}) => {
   a.download = options.fileName || 'Untitled';
   a.href = URL.createObjectURL(data);
 
-  const _reject = () => cleanupListenersAndMaybeReject(reject);
+  const _reject = () => cleanupListenersAndMaybeReject();
   const _resolve = () => {
     if (typeof cleanupListenersAndMaybeReject === 'function') {
       cleanupListenersAndMaybeReject();


### PR DESCRIPTION
fix https://github.com/GoogleChromeLabs/browser-fs-access/issues/106