### PR TITLE
pass handle in filePickerShown callback

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -152,7 +152,7 @@ export function fileSave(
    * A callback to be called when the file picker was shown (which only happens
    * when no `existingHandle` is provided). Defaults to `null`.
    */
-  filePickerShown?: () => void | null
+  filePickerShown?: (handle: FileSystemFileHandle | null) => void | null
 ): Promise<FileSystemFileHandle | null>;
 
 /**

--- a/src/fs-access/file-save.mjs
+++ b/src/fs-access/file-save.mjs
@@ -82,7 +82,7 @@ export default async (
       excludeAcceptAllOption: options[0].excludeAcceptAllOption || false,
     }));
   if (!existingHandle && filePickerShown) {
-    filePickerShown();
+    filePickerShown(handle);
   }
   const writable = await handle.createWritable();
   // Use streaming on the `Blob` if the browser supports it.


### PR DESCRIPTION
I need the name of the file handle, which the user has entered, before the file writing is complete.
Currently the handle is only returned upon completion, but it is actually available right after the file picker was shown.

Even though I don't need the whole handle, only the file name, I return the handle in case it might be useful to others at some point.