### PR TITLE
Remove unnecessary negative conditional

### DIFF
--- a/src/directory-open.mjs
+++ b/src/directory-open.mjs
@@ -17,9 +17,9 @@
 
 import supported from './supported.mjs';
 
-const implementation = !supported
-  ? import('./legacy/directory-open.mjs')
-  : import('./fs-access/directory-open.mjs');
+const implementation = supported
+  ? import('./fs-access/directory-open.mjs')
+  : import('./legacy/directory-open.mjs');
 
 /**
  * For opening directories, dynamically either loads the File System Access API

--- a/src/file-open.mjs
+++ b/src/file-open.mjs
@@ -17,9 +17,9 @@
 
 import supported from './supported.mjs';
 
-const implementation = !supported
-  ? import('./legacy/file-open.mjs')
-  : import('./fs-access/file-open.mjs');
+const implementation = supported
+  ? import('./fs-access/file-open.mjs')
+  : import('./legacy/file-open.mjs');
 
 /**
  * For opening files, dynamically either loads the File System Access API module

--- a/src/file-save.mjs
+++ b/src/file-save.mjs
@@ -17,9 +17,9 @@
 
 import supported from './supported.mjs';
 
-const implementation = !supported
-  ? import('./legacy/file-save.mjs')
-  : import('./fs-access/file-save.mjs');
+const implementation = supported
+  ? import('./fs-access/file-save.mjs')
+  : import('./legacy/file-save.mjs');
 
 /**
  * For saving files, dynamically either loads the File System Access API module


### PR DESCRIPTION
Negative conditionals are smelly and confusing.