### PR TITLE
Adds exported types to moduleResolution:node16

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     ".": {
       "module": "./dist/index.modern.js",
       "import": "./dist/index.modern.js",
-      "require": "./dist/index.cjs"
+      "require": "./dist/index.cjs",
+      "types": "./index.d.ts"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
This will let users get type information when compiling ESM projects with node module settings in later versions of tsc and node 18+